### PR TITLE
delete_column_user-references_from_orders

### DIFF
--- a/db/migrate/20190812022449_tmp.rb
+++ b/db/migrate/20190812022449_tmp.rb
@@ -1,0 +1,5 @@
+class Tmp < ActiveRecord::Migration
+  def change
+     remove_column :orders, :user, :references
+  end
+end


### PR DESCRIPTION
ordersテーブルから、user_idカラム(references)を削除しました。