### PR TITLE
fix view&relation and add validation

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,8 +13,6 @@ class ProductsController < ApplicationController
     @product = Product.new
     @product.product_images.build
 
-    @product.build_category
-
   end
 
   def create
@@ -42,8 +40,8 @@ private
       :delivery_status,
       :delivery_cost,
       :prep_days,
-      product_images_attributes: [:id, :image_url],
-      categories_attributes: [:id, :name]
+      :category_id,
+      product_images_attributes: [:id, :image_url]
     )
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,5 @@
 class Category < ApplicationRecord
   # Association
-
-  # has_many :categories
-  # has_many :products, through: :categories
   has_many :products
   has_ancestry
 end

--- a/app/models/cost.rb
+++ b/app/models/cost.rb
@@ -1,0 +1,5 @@
+class Cost < ActiveHash::Base
+  self.data = [
+    {id: 1, name: "送料込み(出品者負担)"}, {id: 2, name: "着払い(購入者負担)"}
+  ]
+end

--- a/app/models/preparation.rb
+++ b/app/models/preparation.rb
@@ -1,0 +1,5 @@
+class Preparation < ActiveHash::Base
+  self.data = [
+    {id: 1, name: "1~2日で発送"}, {id: 2, name: "2~3日で発送"}, {id: 3, name: "4~7日で発送"}
+  ]
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -18,6 +18,7 @@ class Product < ApplicationRecord
   validates :name, presence: true, length: {maximum: 40}
   validates :description, presence: true, length: {maximum: 1000 }
   validates :price, presence: true, numericality: {less_than: 999999, greater_than: 300}
+  validates :category_id, presence: true
   validates :quality, presence: true
   validates :delivery_origin, presence: true
   validates :delivery_cost, presence: true

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -53,14 +53,13 @@
                         .select-wrap
                           %i.icon-arrow-bottom
                           = f.collection_select :category_id, Category.where(id:1..13), :id,:name, {include_blank: "---"}, class: "select-default"
-                          -# = c.select :name , [[""],["レディース"],["メンズ"],["ベビーキッズ"],["ライフスタイル"],["エンタメ"],["その他"]],{}, include_blank: "---" , class: "select-default"
+
                     .sell-detail__form__status
                       %label
                         商品の状態
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        -# = f.select :quality, [[""],["新品、未使用"],["未使用に近い"],["目立った傷や汚れなし"],["やや傷や汚れあり"],["傷や汚れあり"],["全体的に状態が悪い"]], {} , include_blank: "---", class: "select-default"
                         = f.select :quality, Condition.all.collect {|p| [p.name]}, {include_blank: "---"},{class: "select-default"}
 
                 .sell-deliver
@@ -82,7 +81,6 @@
                       .select-wrap
                         %i.icon-arrow-bottom
                         = f.select :delivery_origin, Prefecture.all.collect {|p| [p.name]}, {include_blank: "---" }, {class: "select-default"}
-                        -# [[""],["北海道"],["青森県"],["岩手県"],["宮城県"],["秋田県"],["山形県"],["福島県"],["茨城県"],["栃木県"],["群馬県"],["埼玉県"],["千葉県"],["東京都"],["神奈川県"],["新潟県"],["富山県"],["石川県"],["福井県"],["山梨県"],["長野県"],["岐阜県"],["静岡県"],["愛知県"],["三重県"],["滋賀県"],["京都府"],["大阪府"],["兵庫県"],["奈良県"],["和歌山県"],["鳥取県"],["島根県"],["岡山県"],["広島県"],["山口県"],["徳島県"],["香川県"],["愛媛県"],["高知県"],["福岡県"],["佐賀県"],["長崎県"],["熊本県"],["大分県"],["宮崎県"],["鹿児島県"],["沖縄県"],["未定"]], {}, include_blank: "---" , class: "select-default"
                     .sell-deliver__form__day
                       %label
                         発送までの日数

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -73,7 +73,7 @@
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        = f.select :delivery_cost, [["送料込み(出品者負担)"],["着払い(購入者負担)"]], {include_blank: "---"}, {class: "select-default"}
+                        = f.select :delivery_cost, Cost.all.collect{|p| [p.name]}, {include_blank: "---"}, {class: "select-default"}
                     .sell-deliver__form__region
                       %label
                         発送元の地域
@@ -87,7 +87,7 @@
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        = f.select :prep_days, [["1~2日で発送"],["2~3日で発送"],["4~7日で発送"]],{include_blank: "---"}, {class: "select-default"}
+                        = f.select :prep_days, Preparation.all.collect{|p| [p.name]},{include_blank: "---"}, {class: "select-default"}
                 .sell-price
                   .sell-price__title 
                     %h3 販売価格(300〜9,999,999)

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -50,18 +50,18 @@
                         カテゴリー
                         %span.require 必須
                       %div
-                      = f.fields_for :categories do |c|
                         .select-wrap
                           %i.icon-arrow-bottom
-                          = c.select :name , [[""],["レディース"],["メンズ"],["ベビーキッズ"],["ライフスタイル"],["エンタメ"],["その他"]],{}, prompt: "" , class: "select-default"
+                          = f.collection_select :category_id, Category.where(id:1..13), :id,:name, {include_blank: "---"}, class: "select-default"
+                          -# = c.select :name , [[""],["レディース"],["メンズ"],["ベビーキッズ"],["ライフスタイル"],["エンタメ"],["その他"]],{}, include_blank: "---" , class: "select-default"
                     .sell-detail__form__status
                       %label
                         商品の状態
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        -# = f.select :quality, [[""],["新品、未使用"],["未使用に近い"],["目立った傷や汚れなし"],["やや傷や汚れあり"],["傷や汚れあり"],["全体的に状態が悪い"]], {} , prompt: "", class: "select-default"
-                        = f.select :quality, Condition.all.collect {|p| [p.name]}, {prompt: ""},{class: "select-default"}
+                        -# = f.select :quality, [[""],["新品、未使用"],["未使用に近い"],["目立った傷や汚れなし"],["やや傷や汚れあり"],["傷や汚れあり"],["全体的に状態が悪い"]], {} , include_blank: "---", class: "select-default"
+                        = f.select :quality, Condition.all.collect {|p| [p.name]}, {include_blank: "---"},{class: "select-default"}
 
                 .sell-deliver
                   .sell-deliver__title 
@@ -74,23 +74,22 @@
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        = f.select :delivery_cost, [[""],["送料込み(出品者負担)"],["着払い(購入者負担)"]], {}, prompt: "" , class: "select-default"
-
+                        = f.select :delivery_cost, [["送料込み(出品者負担)"],["着払い(購入者負担)"]], {include_blank: "---"}, {class: "select-default"}
                     .sell-deliver__form__region
                       %label
                         発送元の地域
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        = f.select :delivery_origin, Prefecture.all.collect {|p| [p.name]}, {prompt: "" }, {class: "select-default"}
-                        -# [[""],["北海道"],["青森県"],["岩手県"],["宮城県"],["秋田県"],["山形県"],["福島県"],["茨城県"],["栃木県"],["群馬県"],["埼玉県"],["千葉県"],["東京都"],["神奈川県"],["新潟県"],["富山県"],["石川県"],["福井県"],["山梨県"],["長野県"],["岐阜県"],["静岡県"],["愛知県"],["三重県"],["滋賀県"],["京都府"],["大阪府"],["兵庫県"],["奈良県"],["和歌山県"],["鳥取県"],["島根県"],["岡山県"],["広島県"],["山口県"],["徳島県"],["香川県"],["愛媛県"],["高知県"],["福岡県"],["佐賀県"],["長崎県"],["熊本県"],["大分県"],["宮崎県"],["鹿児島県"],["沖縄県"],["未定"]], {}, prompt: "" , class: "select-default"
+                        = f.select :delivery_origin, Prefecture.all.collect {|p| [p.name]}, {include_blank: "---" }, {class: "select-default"}
+                        -# [[""],["北海道"],["青森県"],["岩手県"],["宮城県"],["秋田県"],["山形県"],["福島県"],["茨城県"],["栃木県"],["群馬県"],["埼玉県"],["千葉県"],["東京都"],["神奈川県"],["新潟県"],["富山県"],["石川県"],["福井県"],["山梨県"],["長野県"],["岐阜県"],["静岡県"],["愛知県"],["三重県"],["滋賀県"],["京都府"],["大阪府"],["兵庫県"],["奈良県"],["和歌山県"],["鳥取県"],["島根県"],["岡山県"],["広島県"],["山口県"],["徳島県"],["香川県"],["愛媛県"],["高知県"],["福岡県"],["佐賀県"],["長崎県"],["熊本県"],["大分県"],["宮崎県"],["鹿児島県"],["沖縄県"],["未定"]], {}, include_blank: "---" , class: "select-default"
                     .sell-deliver__form__day
                       %label
                         発送までの日数
                         %span.require 必須
                       .select-wrap
                         %i.icon-arrow-bottom
-                        = f.select :prep_days, [[""],["1~2日で発送"],["2~3日で発送"],["4~7日で発送"]], {}, prompt: "" , class: "select-default"
+                        = f.select :prep_days, [["1~2日で発送"],["2~3日で発送"],["4~7日で発送"]],{include_blank: "---"}, {class: "select-default"}
                 .sell-price
                   .sell-price__title 
                     %h3 販売価格(300〜9,999,999)


### PR DESCRIPTION
#WHAT
・productモデルとcategoryモデルとのassociationの変更に伴い、select formの選択肢の表示のさせ方、データの送り先を変更
・ActiveHashを導入し、select formの選択肢を仮モデルから取ることでcodeを見やすく変更。
#WHY
・出品時、categoryを判別するため。
・可読性向上のため。