### PR TITLE
create_breadcrumbs-list

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import 'modules/signupstep4';
 @import 'modules/signupstep5';
 @import 'modules/signup-done';
+@import 'modules/breadcrumbs';
 @import 'modules/devise-footer';
 @import 'modules/devise-header';
 @import 'modules/mypages-logout';

--- a/app/assets/stylesheets/modules/_breadcrumbs.scss
+++ b/app/assets/stylesheets/modules/_breadcrumbs.scss
@@ -1,0 +1,22 @@
+.breadcrumbs{
+  border: solid;
+  border-width: thin;
+  border-color: #eae6e6;
+  background-color: $white;
+  a{
+    text-decoration: none;
+    color: black;
+    display: inline-block;
+  }
+  &_list{
+    height: 49px;
+    line-height: 3.2;
+    margin: 0px 141px;
+    padding: 3px 0px;
+    font-size: 15px;
+    .current{
+      font-weight: 600;
+    }
+  }
+  
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,6 @@
     = csrf_meta_tags
     = csp_meta_tag
     %link(rel="stylesheet" href="https://use.fontawesome.com/releases/v5.9.0/css/all.css")
-    = breadcrumbs pretext: "You are here: ", separator: " &rsaquo; "
     %script{src: "https://js.pay.jp/", type: "text/javascript"}/
     -# 以下の1行は、画像スライドショーを実装するためのコード
     %script{ type: "text/javascript", src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"}

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -1,6 +1,11 @@
 .wrapper
   = render 'shared/header'
   = render 'shared/exhibit-btn'  
+
+  -# 以下の2行はパンくずリストを表示させるコード
+  - breadcrumb :identification_mypages
+  = render "shared/breadcrumbs"
+
   .wrapper-mypage
     .container-mypage
       = render "shared/sidebar"

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -1,6 +1,9 @@
 .wrapper
   = render 'shared/header'
-  = render 'shared/exhibit-btn'  
+  = render 'shared/exhibit-btn' 
+  -# 以下の2行はパンくずリストを表示させるコード
+  - breadcrumb :logout_mypages
+  = render "shared/breadcrumbs"
   .wrapper-mypage
     .container-mypage
       = render partial:"shared/sidebar"

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -1,6 +1,11 @@
 .wrapper
   = render 'shared/header'
   = render 'shared/exhibit-btn'
+  
+  -# 以下の2行はパンくずリストを表示させるコード
+  - breadcrumb :profile_mypages
+  = render "shared/breadcrumbs"
+
   .wrapper-mypage
     .container-mypage
       = render "shared/sidebar"

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs_list"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -2,6 +2,11 @@
   = render 'shared/header'
   = render 'layouts/notifications'
   = render 'shared/exhibit-btn' 
+
+  -# 以下の2行はパンくずリストを表示させるコード
+  - breadcrumb :edit_user
+  = render "shared/breadcrumbs"
+
   .wrapper-mypage
     .container-mypage
       = render "shared/sidebar"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,7 +2,22 @@ crumb :root do
   link "メルカリ", root_path
 end
 
-crumb :mypages do
-  link "マイページ", mypages_path
+crumb :profile_mypages do
+  link "マイページ", profile_mypages_url
   parent :root
+end
+
+crumb :edit_user do
+  link "プロフィール", edit_user_url
+  parent :profile_mypages
+end
+
+crumb :identification_mypages do
+  link "本人情報", identification_mypages_url
+  parent :profile_mypages
+end
+
+crumb :logout_mypages do
+  link "ログアウト", logout_mypages_url
+  parent :profile_mypages
 end


### PR DESCRIPTION
# what
ユーザーのマイページ関連のviewにパンくずリストを実装しました。

# why
ユーザーが迷子にならないようにするため。

# Gyazo GIF
マイページ
https://gyazo.com/a46c0ee83ccac1218367b50bfde2c249

プロフィールページ
https://gyazo.com/ebb83048f2d5612c94e89f096a08f45d

本人情報ページ
https://gyazo.com/ef7bafec12e120ce68ae86bd56646471

ログアウトページ
https://gyazo.com/7c82d33344032cd1b95285382adb5e95


